### PR TITLE
breaking change: credential_pop is an array

### DIFF
--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -331,7 +331,7 @@ Content-Type: application/json
 Given that the Wallet may request one or more Status Attestations from the same Credential Issuer,
 the `status_assertion_requests` parameter is subject to the following specification:
 - Status_assertion_requests: REQUIRED. It MUST be implemented as an array of strings,
-where each string represents a Digital Credential proof of possession
+Each string within the array is a Digital Credential Status Assertion Request.
 - The position of each `$StatusAssertionRequest` object
 within the array MUST match the same position in the subsequent response.
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -328,9 +328,10 @@ Content-Type: application/json
 "status_assertion_requests" : ["${base64url(json({typ: (some pop for status-assertion)+jwt, ...}))}.payload.signature", ... ]
 ~~~
 
-Given that the Wallet may request one or more Status Attestations from the same Credential Issuer,
-the `status_assertion_requests` parameter is subject to the following specification:
-- Status_assertion_requests: REQUIRED. It MUST be implemented as an array of strings,
+The Status Assertion HTTP request can be sent to a single Credential Issuer regarding multiple Digital Credentials, and MUST contain a json object with the member `status_assertion_requests`.
+
+The `status_assertion_requests` MUST be set with an array of strings.
+
 Each string within the array is a Digital Credential Status Assertion Request.
 
 The Credential Issuer that receives the Status Assertion Request MUST validate that the Wallet Instance making the request is authorized to request Status Assertions.
@@ -494,7 +495,7 @@ Content-Type: application/json
 }
 ~~~
 
-The member `status_assertion_responses` MUST be an array of strings, 
+The member `status_assertion_responses` MUST be an array of strings,
 where each of them represent a Status Assertion Response object. In particular:
 to the following specification:
 - Each element in the array MUST match the element contained in the request at the same position

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -327,11 +327,7 @@ encoding, for better readability:
 
 When the JWT format is used, the JWT MUST contain the parameters defined in the following table.
 
-<<<<<<< SaraConsoliACN-20240503_1
 | JOSE Header Parameter | Description | Reference |
-=======
-| Header | Description | Reference |
->>>>>>> main
 | --- | --- | --- |
 | **typ** | It MUST be set to `status-assertion-request+jwt` | {{RFC7516}} Section 4.1.1 |
 | **alg** | A digital signature algorithm identifier such as per IANA "JSON Web Signature and Encryption Algorithms" registry. It MUST NOT be set to `none` or any symmetric algorithm (MAC) identifier. | {{RFC7516}} Section 4.1.1 |

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -503,7 +503,7 @@ where each of them represent a Status Assertion Response object and the followin
 - Each element in the array MUST match the corresponding element in the request array at the same index
 - Each element MUST contain the error or the status of the assertion using the `typ` member
 set to "status-assertion-error+{jwt,cwt}" or "status-assertion+{jwt,cwt}"
-- The corresponding entry in the response must be of the same type as requested. For example,
+- The corresponding entry in the response MUST be of the same type as requested. For example,
 if the entry in the request is "jwt",
 then the entry at the same position in the response must also be "jwt".
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -328,7 +328,7 @@ Given that the Wallet may request one or more Status Attestations from the same 
 the `status_assertion_requests` parameter is subject to the following specification:
 - Status_assertion_requests: REQUIRED. It MUST be implemented as an array of strings,
 where each string represents a Digital Credential proof of possession
-- The position of each `$StatusAssertionRequest` object 
+- The position of each `$StatusAssertionRequest` object
 within the array MUST match the same position in the subsequent response.
 
 To validate that the Wallet Instance is entitled to request its Status Assertion,
@@ -464,9 +464,9 @@ The Status Assertion MUST contain the following claims when the JWT format is us
 | **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be greater than the value 
 set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **credential_hash** | Hash value of the Digital Credential the Status Assertion is bound to. | this specification |
-| **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound. 
+| **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound.
 The value SHOULD be set to `sha-256`. | this specification |
-| **cnf** | JSON object containing the cryptographic key binding. The `cnf.jwk` value MUST match 
+| **cnf** | JSON object containing the cryptographic key binding. The `cnf.jwk` value MUST match
 with the one provided within the related Digital Credential. | {{RFC7800}} Section 3.1 |
 
 
@@ -492,13 +492,13 @@ Content-Type: application/json
 }
 ~~~
 
-Given that the member `status_assertion_responses` is an array of strings, it is subject 
+Given that the member `status_assertion_responses` is an array of strings, it is subject
 to the following specification:
 - Each element in the array MUST match the element contained in the request at the same position
-- Each element MUST contain the error or the status of the assertion using the `typ` member 
+- Each element MUST contain the error or the status of the assertion using the `typ` member
 set to "status-assertion-error+{jwt,cwt}" 
 or "status-assertion+{jwt,cwt}"
-- The corresponding entry in the response must be of the same type as requested. For example, 
+- The corresponding entry in the response must be of the same type as requested. For example,
 if the entry in the request is "jwt", 
 then the entry at the same position in the response must also be "jwt".
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -335,7 +335,7 @@ Each string within the array is a Digital Credential Status Assertion Request.
 - The position of each `$StatusAssertionRequest` object
 within the array MUST match the same position in the subsequent response.
 
-To validate that the Wallet Instance is entitled to request its Status Assertion,
+The Credential Issuer that receives the Status Assertion Request MUST validate that the Wallet Instance making the request is authorized to request Status Assertions.
 the following requirements MUST be satisfied:
 
 - The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -236,10 +236,10 @@ related to a specific Credential issued by the same Credential Issuer.
 +--------+----------+                         +----------+---------+
          |                                               |
          | HTTP POST /status                             |
-         |  credential_pop = [$CredentialPoPJWT]         |
+         |  parameters_pop = [$CredentialPoP]            |
          +----------------------------------------------->
          |                                               |
-         |  Response with Status Attestation JWT         |
+         |  Response with Status Attestation             |
          <-----------------------------------------------+
          |                                               |
 +--------+----------+                         +----------+---------+
@@ -260,19 +260,19 @@ POST /status HTTP/1.1
 Host: issuer.example.org
 Content-Type: application/json
 
-{ "credential_pop" : [$CredentialPoPJWT, $CredentialPoPCWT, ... ] }
+{ "parameters_pop" : [$CredentialPoPJWT, $CredentialPoPCWT, ... ] }
 ~~~
 
-Given that the Wallet may request one or more Status Attestations from the same Credential Issuer, the `credential_pop` parameter is subject to the following specification:
-- credential_pop: REQUIRED. It MUST be implemented as an array of strings, where each string represents a Digital Credential proof of possession.
+Given that the Wallet may request one or more Status Attestations from the same Credential Issuer, the `parameters_pop` parameter is subject to the following specification:
+- parameters_pop: REQUIRED. It MUST be implemented as an array of strings, where each string represents a Digital Credential proof of possession.
 
 To validate that the Wallet Instance is entitled to request its Status Attestation,
 the following requirements MUST be satisfied:
 
-- The Credential Issuer MUST verify the signature of all elements in the `credential_pop` object using the public key contained within the Digital Credential where the `credential_pop` is referred to;
-- the Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential to which the `credential_pop` refers.
+- The Credential Issuer MUST verify the signature of all elements in the `parameters_pop` object using the public key contained within the Digital Credential where the `parameters_pop` is referred to;
+- the Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential to which the `parameters_pop` refers.
 
-The technical and details about the `credential_pop` object
+The technical and details about the `parameters_pop` object
 are defined in the next section.
 
 ## Status Attestation Request Errors

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -342,7 +342,7 @@ Therefore the following requirements MUST be satisfied:
 
 - The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object
 using the confirmation method contained within the Digital Credential where the `status_assertion_requests` is referred to;
-- the Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential
+- The Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential
 to which the `status_assertion_requests` refers.
 
 The technical and details about the `status_assertion_requests` object

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -297,7 +297,7 @@ related to a specific Credential issued by the same Credential Issuer.
          |  status_assertion_requests = [$StatusAssertionRequest] |
          +-------------------------------------------------------->
          |                                                        |
-         |  Response with Status Assertion                        |
+         |  Status Assertion Responses [...]                      |
          <--------------------------------------------------------+
          |                                                        |
 +--------+----------+                                  +----------+---------+

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -332,8 +332,6 @@ Given that the Wallet may request one or more Status Attestations from the same 
 the `status_assertion_requests` parameter is subject to the following specification:
 - Status_assertion_requests: REQUIRED. It MUST be implemented as an array of strings,
 Each string within the array is a Digital Credential Status Assertion Request.
-- The position of each `$StatusAssertionRequest` object
-within the array MUST match the same position in the subsequent response.
 
 The Credential Issuer that receives the Status Assertion Request MUST validate that the Wallet Instance making the request is authorized to request Status Assertions.
 Therefore the following requirements MUST be satisfied:

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -258,9 +258,9 @@ to the public key attested by the Credential Issuer and contained within the Dig
 ~~~
 POST /status HTTP/1.1
 Host: issuer.example.org
-Content-Type: application/x-www-form-urlencoded
+Content-Type: application/json
 
-credential_pop=[$CredentialPoPJWT]
+{ "credential_pop" : [$CredentialPoPJWT, $CredentialPoPCWT, ... ] }
 ~~~
 
 Given that the Wallet may request one or more Status Attestations from the same Credential Issuer, the `credential_pop` parameter is subject to the following specification:

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -328,13 +328,17 @@ Content-Type: application/json
 "status_assertion_requests" : ["${base64url(json({typ: (some pop for status-assertion)+jwt, ...}))}.payload.signature", ... ]
 ~~~
 
-The Status Assertion HTTP request can be sent to a single Credential Issuer regarding multiple Digital Credentials, and MUST contain a json object with the member `status_assertion_requests`.
+The Status Assertion HTTP request can be sent to a single Credential Issuer
+regarding multiple Digital Credentials, and MUST contain a json object with
+the member `status_assertion_requests`.
 
 The `status_assertion_requests` MUST be set with an array of strings.
 
 Each string within the array is a Digital Credential Status Assertion Request.
 
-The Credential Issuer that receives the Status Assertion Request MUST validate that the Wallet Instance making the request is authorized to request Status Assertions.
+The Credential Issuer that receives the Status Assertion Request
+MUST validate that the Wallet Instance making the request is
+authorized to request Status Assertions.
 Therefore the following requirements MUST be satisfied:
 
 - The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -500,7 +500,7 @@ Content-Type: application/json
 
 The member `status_assertion_responses` MUST be an array of strings,
 where each of them represent a Status Assertion Response object and the following requirements are met:
-- Each element in the array MUST match the corresponding element in the request array at the same index
+- Each element in the array MUST match the corresponding element in the request array at the same index to which it is related.
 - Each element MUST contain the error or the status of the assertion using the `typ` member
 set to "status-assertion-error+{jwt,cwt}" or "status-assertion+{jwt,cwt}"
 - The corresponding entry in the response MUST be of the same type as requested. For example,

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -496,7 +496,8 @@ Content-Type: application/json
 }
 ~~~
 
-Given that the member `status_assertion_responses` is an array of strings, it is subject
+The member `status_assertion_responses` MUST be an array of strings, 
+where each of them represent a Status Assertion Response object. In particular:
 to the following specification:
 - Each element in the array MUST match the element contained in the request at the same position
 - Each element MUST contain the error or the status of the assertion using the `typ` member

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -336,7 +336,7 @@ Each string within the array is a Digital Credential Status Assertion Request.
 within the array MUST match the same position in the subsequent response.
 
 The Credential Issuer that receives the Status Assertion Request MUST validate that the Wallet Instance making the request is authorized to request Status Assertions.
-the following requirements MUST be satisfied:
+Therefore the following requirements MUST be satisfied:
 
 - The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object
 using the public key contained within the Digital Credential where the `status_assertion_requests` is referred to;

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -341,9 +341,9 @@ authorized to request Status Assertions.
 Therefore the following requirements MUST be satisfied:
 
 - The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object
-using the confirmation method contained within the Digital Credential where the `status_assertion_requests` is referred to;
+using the confirmation method contained within the Digital Credential where the Status Assertion Request object is referred to;
 - The Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential
-to which the `status_assertion_requests` refers.
+to which each Status Assertion Request object refers.
 
 The technical and details about the `status_assertion_requests` object
 are defined in the next section.
@@ -372,7 +372,7 @@ Below a non-normative example of an HTTP Response with an error.
 
   {
     "error": "invalid_request"
-    "error_description": "The signature of credential_pop JWT is not valid"
+    "error_description": "The signature of the status assertion request is not valid"
   }
 ~~~
 
@@ -486,8 +486,8 @@ code set to 404.
 If the Digital Credential is valid, the Credential Issuer MUST return
 an HTTP status code of 201 (Created), with the content type set to
 `application/json`. The response MUST include a JSON object with a member
-named `status_assertion_responses`, which contains the Status Assertion for the
-Wallet Instance, as illustrated in the following non-normative example:
+named `status_assertion_responses`, which contains the Status Assertions and or the Status Assertion Errors related to the request made by the
+Wallet Instance. In the non-normative example below is represented an HTTP Response with the `status_assertion_responses` JSON member:
 
 ~~~
 HTTP/1.1 201 Created
@@ -499,10 +499,11 @@ Content-Type: application/json
 ~~~
 
 The member `status_assertion_responses` MUST be an array of strings,
-where each of them represent a Status Assertion Response object and the following requirements are met:
+where each of them represent a Status Assertion Response object or a Status Assertion Error object.
+For each entry in the `status_assertion_responses` array, the following requirements are met:
 - Each element in the array MUST match the corresponding element in the request array at the same index to which it is related.
 - Each element MUST contain the error or the status of the assertion using the `typ` member.
-set to "status-assertion-error+{jwt,cwt}" or "status-assertion+{jwt,cwt}"
+set to "status-assertion-error+{jwt,cwt}" or "status-assertion+{jwt,cwt}", depending by the object type.
 - The corresponding entry in the response MUST be of the same type as requested. For example,
 if the entry in the request is "jwt",
 then the entry at the same position in the response must also be "jwt".

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -393,7 +393,7 @@ The Status Attestation MUST contain the following claims when the JWT format is 
 If the Status Attestation is requested for a non-existent, expired, revoked or invalid Digital Credential, the
 Credential Issuer MUST respond with an HTTP Response with the status code set to 404.
 
-If the Digital Credential is valid, the Credential Issuer MUST return an HTTP status code of 201 (Created), with the content type set to `application/json`. The response MUST include a JSON object with a member named `status_attestations`, which contains a list of Status Attestation for the Wallet Instance, as illustrated in the following non-normative example:
+If the Digital Credential is valid, the Credential Issuer MUST return an HTTP status code of 201 (Created), with the content type set to `application/json`. The response MUST include a JSON object with a member named `status_attestations`, which contains a list of Status Attestations, as illustrated in the following non-normative example:
 
 ~~~
 HTTP/1.1 201 Created

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -236,7 +236,7 @@ related to a specific Credential issued by the same Credential Issuer.
 +--------+----------+                         +----------+---------+
          |                                               |
          | HTTP POST /status                             |
-         |  parameters_pop = [$CredentialPoP]            |
+         |  credential_pop = [$CredentialPoP]            |
          +----------------------------------------------->
          |                                               |
          |  Response with Status Assertion               |

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -393,7 +393,7 @@ The Status Attestation MUST contain the following claims when the JWT format is 
 If the Status Attestation is requested for a non-existent, expired, revoked or invalid Digital Credential, the
 Credential Issuer MUST respond with an HTTP Response with the status code set to 404.
 
-If the Digital Credential is valid, the Credential Issuer MUST return an HTTP status code of 201 (Created), with the content type set to `application/json`. The response MUST include a JSON object with a member named `status_attestation`, which contains the Status Attestation for the Wallet Instance, as illustrated in the following non-normative example:
+If the Digital Credential is valid, the Credential Issuer MUST return an HTTP status code of 201 (Created), with the content type set to `application/json`. The response MUST include a JSON object with a member named `status_attestations`, which contains a list of Status Attestation for the Wallet Instance, as illustrated in the following non-normative example:
 
 ~~~
 HTTP/1.1 201 Created
@@ -404,8 +404,8 @@ Content-Type: application/json
 }
 ~~~
 
-The status_attestation object MUST adhere to the following specification:
-- `status_attestation`. REQUIRED. By default, it MUST be an array of strings (array[string]).
+The status_attestations object MUST adhere to the following specification:
+- `status_attestations`. REQUIRED. By default, it MUST be an array of strings (array[string]).
 
 # Credential Issuers Supporting Status Attestations
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -500,7 +500,7 @@ Content-Type: application/json
 
 The member `status_assertion_responses` MUST be an array of strings,
 where each of them represent a Status Assertion Response object and the following requirements are met:
-- Each element in the array MUST match the element contained in the request at the same position
+- Each element in the array MUST match the corresponding element in the request array at the same index
 - Each element MUST contain the error or the status of the assertion using the `typ` member
 set to "status-assertion-error+{jwt,cwt}"
 or "status-assertion+{jwt,cwt}"

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -400,7 +400,7 @@ HTTP/1.1 201 Created
 Content-Type: application/json
 
 {
-    "status_attestation": ["eyJhbGciOiJFUzI1Ni ...", "..."],
+    "status_attestations": ["eyJhbGciOiJFUzI1Ni ...", "..."],
 }
 ~~~
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -382,7 +382,7 @@ The Status Attestation MUST contain the following claims when the JWT format is 
 | --- | --- | --- |
 | **iss** | It MUST be set to the identifier of the Issuer. | {{RFC9126}}, {{RFC7519}} |
 | **iat** | UNIX Timestamp with the time of the Status Attestation issuance. | {{RFC9126}}, {{RFC7519}} |
-| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be superior to the value set for `iat`  . | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
+| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be superior to the value set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **credential_hash** | Hash value of the Digital Credential the Status Attestation is bound to. | this specification |
 | **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Attestation is bound. The value SHOULD be set to `sha-256`. | this specification |
 | **cnf** | JSON object containing the cryptographic key binding. The `cnf.jwk` value MUST match with the one provided within the related Digital Credential. | {{RFC7800}} Section 3.1 |

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -269,8 +269,7 @@ Given that the Wallet may request one or more Status Attestations from the same 
 To validate that the Wallet Instance is entitled to request its Status Attestation,
 the following requirements MUST be satisfied:
 
-- The Credential Issuer MUST verify the signature for all array elements into `credential_pop` object using
-the public key contained in the Digital Credential;
+- The Credential Issuer MUST verify the signature of all elements in the `credential_pop` object using the public key contained within the Digital Credential where the `credential_pop` is referred to;
 - the Credential Issuer MUST verify that it is the legitimate Issuer.
 
 The technical and details about the `credential_pop` object

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -338,7 +338,7 @@ The Credential Issuer that receives the Status Assertion Request MUST validate t
 Therefore the following requirements MUST be satisfied:
 
 - The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object
-using the public key contained within the Digital Credential where the `status_assertion_requests` is referred to;
+using the confirmation method contained within the Digital Credential where the `status_assertion_requests` is referred to;
 - the Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential
 to which the `status_assertion_requests` refers.
 
@@ -469,7 +469,7 @@ set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **credential_hash** | Hash value of the Digital Credential the Status Assertion is bound to. | this specification |
 | **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound.
 The value SHOULD be set to `sha-256`. | this specification |
-| **cnf** | JSON object containing the cryptographic key binding. The `cnf.jwk` value MUST match
+| **cnf** | JSON object containing the confirmation method. The `cnf.jwk` value MUST match
 with the one provided within the related Digital Credential. | {{RFC7800}} Section 3.1 |
 
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -270,7 +270,7 @@ To validate that the Wallet Instance is entitled to request its Status Attestati
 the following requirements MUST be satisfied:
 
 - The Credential Issuer MUST verify the signature of all elements in the `credential_pop` object using the public key contained within the Digital Credential where the `credential_pop` is referred to;
-- the Credential Issuer MUST verify that it is the legitimate Issuer.
+- the Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential to which the `credential_pop` refers.
 
 The technical and details about the `credential_pop` object
 are defined in the next section.

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -337,7 +337,7 @@ When the JWT format is used, the JWT MUST contain the parameters defined in the 
 | --- | --- | --- |
 | **iss** | Wallet identifier. | {{RFC9126}}, {{RFC7519}} |
 | **aud** | It MUST be set with the Credential Issuer Status Assertion endpoint URL as value that identify the intended audience | {{RFC9126}}, {{RFC7519}} |
-| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be superior to the value set for `iat`  . | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
+| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be greater than the value set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **iat** | UNIX Timestamp with the time of JWT issuance. | {{RFC9126}}, {{RFC7519}} |
 | **jti** | Unique identifier for the JWT.  | {{RFC7519}} Section 4.1.7 |
 | **credential_hash** | Hash value of the Digital Credential the Status Assertion is bound to. | this specification |
@@ -382,7 +382,7 @@ The Status Assertion MUST contain the following claims when the JWT format is us
 | --- | --- | --- |
 | **iss** | It MUST be set to the identifier of the Issuer. | {{RFC9126}}, {{RFC7519}} |
 | **iat** | UNIX Timestamp with the time of the Status Assertion issuance. | {{RFC9126}}, {{RFC7519}} |
-| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be superior to the value set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
+| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be greater than the value set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **credential_hash** | Hash value of the Digital Credential the Status Assertion is bound to. | this specification |
 | **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound. The value SHOULD be set to `sha-256`. | this specification |
 | **cnf** | JSON object containing the cryptographic key binding. The `cnf.jwk` value MUST match with the one provided within the related Digital Credential. | {{RFC7800}} Section 3.1 |

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -328,7 +328,7 @@ Content-Type: application/json
 "status_assertion_requests" : ["${base64url(json({typ: (some pop for status-assertion)+jwt, ...}))}.payload.signature", ... ]
 ~~~
 
-Given that the Wallet may request one or more Status Attestations from the same Credential Issuer, 
+Given that the Wallet may request one or more Status Attestations from the same Credential Issuer,
 the `status_assertion_requests` parameter is subject to the following specification:
 - Status_assertion_requests: REQUIRED. It MUST be implemented as an array of strings,
 where each string represents a Digital Credential proof of possession
@@ -465,7 +465,7 @@ The Status Assertion MUST contain the following claims when the JWT format is us
 | --- | --- | --- |
 | **iss** | It MUST be set to the identifier of the Issuer. | {{RFC9126}}, {{RFC7519}} |
 | **iat** | UNIX Timestamp with the time of the Status Assertion issuance. | {{RFC9126}}, {{RFC7519}} |
-| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be greater than the value 
+| **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be greater than the value
 set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **credential_hash** | Hash value of the Digital Credential the Status Assertion is bound to. | this specification |
 | **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound.
@@ -500,10 +500,10 @@ Given that the member `status_assertion_responses` is an array of strings, it is
 to the following specification:
 - Each element in the array MUST match the element contained in the request at the same position
 - Each element MUST contain the error or the status of the assertion using the `typ` member
-set to "status-assertion-error+{jwt,cwt}" 
+set to "status-assertion-error+{jwt,cwt}"
 or "status-assertion+{jwt,cwt}"
 - The corresponding entry in the response must be of the same type as requested. For example,
-if the entry in the request is "jwt", 
+if the entry in the request is "jwt",
 then the entry at the same position in the response must also be "jwt".
 
 # Interoperability of Credential Issuers Supporting Status Assertions

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -316,6 +316,10 @@ object as proof of possession.
 to the confirmation claim assigned by the issuer and contained within
 the Digital Credential.
 
+
+Below a non-normative example representing a Status Assertion Request array with a
+single JWT in it.
+
 ~~~
 POST /status HTTP/1.1
 Host: issuer.example.org

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -329,7 +329,7 @@ Content-Type: application/json
 ~~~
 
 The Status Assertion HTTP request can be sent to a single Credential Issuer
-regarding multiple Digital Credentials, and MUST contain a json object with
+regarding multiple Digital Credentials, and MUST contain a JSON object with
 the member `status_assertion_requests`.
 
 The `status_assertion_requests` MUST be set with an array of strings, where
@@ -421,7 +421,7 @@ When the JWT format is used, the JWT MUST contain the parameters defined in the 
 | Payload | Description | Reference |
 | --- | --- | --- |
 | **iss** | Wallet identifier. | {{RFC9126}}, {{RFC7519}} |
-| **aud** | It MUST be set with the Credential Issuer Status Assertion endpoint URL as value that identify the intended audience | {{RFC9126}}, {{RFC7519}} |
+| **aud** | It MUST be set with the Credential Issuer Status Assertion endpoint URL as value that identify the intended audience. | {{RFC9126}}, {{RFC7519}} |
 | **iat** | UNIX Timestamp with the time of JWT issuance. | {{RFC9126}}, {{RFC7519}} |
 | **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be greater than the value set for `iat`. | {{RFC9126}}, {{RFC7519}} |
 | **jti** | Unique identifier for the JWT.  | {{RFC7519}} Section 4.1.7 |

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -499,8 +499,7 @@ Content-Type: application/json
 ~~~
 
 The member `status_assertion_responses` MUST be an array of strings,
-where each of them represent a Status Assertion Response object. In particular:
-to the following specification:
+where each of them represent a Status Assertion Response object and the following requirements are met:
 - Each element in the array MUST match the element contained in the request at the same position
 - Each element MUST contain the error or the status of the assertion using the `typ` member
 set to "status-assertion-error+{jwt,cwt}"

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -404,8 +404,6 @@ Content-Type: application/json
 }
 ~~~
 
-The status_attestations object MUST adhere to the following specification:
-- `status_attestations`. REQUIRED. By default, it MUST be an array of strings (array[string]).
 
 # Credential Issuers Supporting Status Attestations
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -502,8 +502,7 @@ The member `status_assertion_responses` MUST be an array of strings,
 where each of them represent a Status Assertion Response object and the following requirements are met:
 - Each element in the array MUST match the corresponding element in the request array at the same index
 - Each element MUST contain the error or the status of the assertion using the `typ` member
-set to "status-assertion-error+{jwt,cwt}"
-or "status-assertion+{jwt,cwt}"
+set to "status-assertion-error+{jwt,cwt}" or "status-assertion+{jwt,cwt}"
 - The corresponding entry in the response must be of the same type as requested. For example,
 if the entry in the request is "jwt",
 then the entry at the same position in the response must also be "jwt".

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -47,7 +47,7 @@ informative:
 Status Assertion is a signed object that demonstrates the validity status of a
 digital credential.
 These assertions are periodically provided
-to holders, who can present these to Verifiers along
+to holders, who can present these to verifier along
 with the corresponding digital credentials.
 The approach outlined in this document
 makes the verifier able to check the non-revocation of a digital credential
@@ -58,7 +58,7 @@ without requiring to query any third-party entities.
 # Introduction
 
 Status Assertions ensure the integrity and trustworthiness of digital credentials, whether in JSON Web Tokens (JWT) or CBOR Web Tokens (CWT) format, certifying their validity and non-revocation status. They function similarly to OCSP Stapling, allowing wallet instances to present time-stamped assertions from the Credential Issuer.
-The approach defined in this specification allows the verification of credentials against any revocation, without direct queries to the issuer, enhancing privacy, reducing latency, and enabling offline verification. Essential for offline scenarios, Status Assertions validate digital credentials' validity, balancing scalability, security, and privacy without internet connectivity.
+The approach defined in this specification allows the verification of credentials against any revocation, without direct queries to the issuer, enhancing privacy, reducing latency, and enabling offline verification.
 
 
 ~~~ ascii-art
@@ -239,7 +239,7 @@ related to a specific Credential issued by the same Credential Issuer.
          |  parameters_pop = [$CredentialPoP]            |
          +----------------------------------------------->
          |                                               |
-         |  Response with Status Assertion JWT           |
+         |  Response with Status Assertion               |
          <-----------------------------------------------+
          |                                               |
 +--------+----------+                         +----------+---------+

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -332,9 +332,8 @@ The Status Assertion HTTP request can be sent to a single Credential Issuer
 regarding multiple Digital Credentials, and MUST contain a json object with
 the member `status_assertion_requests`.
 
-The `status_assertion_requests` MUST be set with an array of strings.
-
-Each string within the array is a Digital Credential Status Assertion Request.
+The `status_assertion_requests` MUST be set with an array of strings, where
+each string within the array represents a Digital Credential Status Assertion Request.
 
 The Credential Issuer that receives the Status Assertion Request
 MUST validate that the Wallet Instance making the request is

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -393,7 +393,7 @@ The Status Attestation MUST contain the following claims when the JWT format is 
 If the Status Attestation is requested for a non-existent, expired, revoked or invalid Digital Credential, the
 Credential Issuer MUST respond with an HTTP Response with the status code set to 404.
 
-If the Digital Credential is valid, the Credential Issuer MUST return an HTTP status code of 201 (Created), with the content type set to `application/json`. The response MUST include a JSON object with a member named `status_attestations`, which contains a list of Status Attestations, as illustrated in the following non-normative example:
+If the Digital Credential is valid, the Credential Issuer MUST return an HTTP status code of 201 (Created), with the content type set to `application/json`. The response MUST include a JSON object with a member named `status_attestations`, which contains an array of strings. Each string in the array represents a Status Attestation, as illustrated in the following non-normative example:
 
 ~~~
 HTTP/1.1 201 Created

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -263,8 +263,8 @@ Content-Type: application/x-www-form-urlencoded
 credential_pop=[$CredentialPoPJWT]
 ~~~
 
-Since the Wallet may request one or more Status Attestations, issued by the same Credential Issuer, the credential_pop object MUST adhere to the following specification:
-- `credential_pop`. REQUIRED. By default, it MUST be an array of strings (array[string]).
+Given that the Wallet may request one or more Status Attestations from the same Credential Issuer, the `credential_pop` parameter is subject to the following specification:
+- credential_pop: REQUIRED. It MUST be implemented as an array of strings, where each string represents a Digital Credential proof of possession.
 
 To validate that the Wallet Instance is entitled to request its Status Attestation,
 the following requirements MUST be satisfied:

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -326,7 +326,7 @@ Content-Type: application/json
 
 Given that the Wallet may request one or more Status Attestations from the same Credential Issuer, 
 the `status_assertion_requests` parameter is subject to the following specification:
-- Status_assertion_requests: REQUIRED. It MUST be implemented as an array of strings, 
+- Status_assertion_requests: REQUIRED. It MUST be implemented as an array of strings,
 where each string represents a Digital Credential proof of possession
 - The position of each `$StatusAssertionRequest` object 
 within the array MUST match the same position in the subsequent response.
@@ -334,9 +334,9 @@ within the array MUST match the same position in the subsequent response.
 To validate that the Wallet Instance is entitled to request its Status Assertion,
 the following requirements MUST be satisfied:
 
-- The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object 
+- The Credential Issuer MUST verify the signature of all elements in the `status_assertion_requests` object
 using the public key contained within the Digital Credential where the `status_assertion_requests` is referred to;
-- the Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential 
+- the Credential Issuer MUST verify that it is the legitimate Issuer of the Digital Credential
 to which the `status_assertion_requests` refers.
 
 The technical and details about the `status_assertion_requests` object

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -501,7 +501,7 @@ Content-Type: application/json
 The member `status_assertion_responses` MUST be an array of strings,
 where each of them represent a Status Assertion Response object and the following requirements are met:
 - Each element in the array MUST match the corresponding element in the request array at the same index to which it is related.
-- Each element MUST contain the error or the status of the assertion using the `typ` member
+- Each element MUST contain the error or the status of the assertion using the `typ` member.
 set to "status-assertion-error+{jwt,cwt}" or "status-assertion+{jwt,cwt}"
 - The corresponding entry in the response MUST be of the same type as requested. For example,
 if the entry in the request is "jwt",

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -472,7 +472,7 @@ set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **credential_hash** | Hash value of the Digital Credential the Status Assertion is bound to. | this specification |
 | **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound.
 The value SHOULD be set to `sha-256`. | this specification |
-| **cnf** | JSON object containing the confirmation method. The `cnf.jwk` value MUST match
+| **cnf** | JSON object containing the confirmation method. Its value MUST be compliant with one contained in the related Digital Credential. For instance, if `cnf.jwk` is used within the Digital Credential, the same value MUST set within the Status Assertion Request.
 with the one provided within the related Digital Credential. | {{RFC7800}} Section 3.1 |
 
 


### PR DESCRIPTION
This PR:
- Addresses issue #30
- Fixes some editorial issues
- Adds a note on the 'exp' parameter, which must be greater than the 'iat' parameter
